### PR TITLE
Fix memleak

### DIFF
--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -25,6 +25,8 @@ class Carrier extends EventEmitter {
     this.player = player
     this.colour = player.colour.value
     this.lightYearDistance = lightYearDistance
+    // Add a larger hit radius so that the star is easily clickable
+    this.graphics_ship.hitArea = new PIXI.Circle(this.data.location.x, this.data.location.y, 10)
   }
 
   draw () {
@@ -90,8 +92,6 @@ class Carrier extends EventEmitter {
 
     this._rotateCarrierTowardsWaypoint(this.graphics_ship)
 
-    // Add a larger hit radius so that the star is easily clickable
-    this.graphics_ship.hitArea = new PIXI.Circle(this.data.location.x, this.data.location.y, 10)
   }
 
   drawGarrison () {

--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -95,7 +95,9 @@ class Carrier extends EventEmitter {
   }
 
   drawGarrison () {
+
     if (this.text_garrison) {
+      this.text_garrison.texture.destroy(true)
       this.container.removeChild(this.text_garrison)
       this.text_garrison = null
     }
@@ -104,20 +106,19 @@ class Carrier extends EventEmitter {
       let style = TextureService.DEFAULT_FONT_STYLE
       style.fontSize = 4
 
-      this.text_garrison = new PIXI.Text('', style)
+      let totalGarrison = this.data.ships == null ? '???' : this.data.ships
+      
+      let garrisonText = totalGarrison.toString() + (this.data.isGift ? '🎁' : '')
+
+      this.text_garrison = new PIXI.Text(garrisonText, style)
       this.text_garrison.resolution = 10
+
+      this.text_garrison.x = this.data.location.x - (this.text_garrison.width / 2)
+      this.text_garrison.y = this.data.location.y + 5
 
       this.container.addChild(this.text_garrison)
     }
 
-    let totalGarrison = this.data.ships == null ? '???' : this.data.ships
-    
-    let garrisonText = totalGarrison.toString() + (this.data.isGift ? '🎁' : '')
-
-    this.text_garrison.text = garrisonText
-    this.text_garrison.x = this.data.location.x - (this.text_garrison.width / 2)
-    this.text_garrison.y = this.data.location.y + 5
-    this.text_garrison.visible = !this.data.orbiting && (this.isSelected || this.isMouseOver || this.zoomPercent < 50)
   }
 
   drawSpecialist () {
@@ -189,6 +190,10 @@ class Carrier extends EventEmitter {
     }
   }
 
+  updateVisible() {
+    this.text_garrison.visible = !this.data.orbiting && (this.isSelected || this.isMouseOver || this.zoomPercent < 50)
+  }
+
   deselectAllText () {
     if (window.getSelection) {window.getSelection().removeAllRanges();}
     else if (document.selection) {document.selection.empty();}
@@ -215,8 +220,7 @@ class Carrier extends EventEmitter {
 
   refreshZoom (zoomPercent) {
     this.zoomPercent = zoomPercent
-
-    this.drawGarrison()
+    this.updateVisible()
   }
 }
 

--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -26,7 +26,7 @@ class Carrier extends EventEmitter {
     this.colour = player.colour.value
     this.lightYearDistance = lightYearDistance
     // Add a larger hit radius so that the star is easily clickable
-    this.graphics_ship.hitArea = new PIXI.Circle(this.data.location.x, this.data.location.y, 10)
+    this.container.hitArea = new PIXI.Circle(this.data.location.x, this.data.location.y, 10)
   }
 
   draw () {

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -332,7 +332,7 @@ class Map extends EventEmitter {
     this.stars
       .forEach(s => {
         s.isSelected = false
-        s.drawActive(false) // Should be fine to pass in false for force
+        s.updateVisibility() // Should be fine to pass in false for force
       })
   }
 
@@ -340,7 +340,7 @@ class Map extends EventEmitter {
     this.carriers
       .forEach(c => {
         c.isSelected = false
-        c.drawActive()
+        //c.updateVisibility()
       })
   }
 
@@ -353,7 +353,7 @@ class Map extends EventEmitter {
           s.isSelected = false
         }
 
-        s.drawActive(false) // Should be fine to pass in false for the force param
+        s.updateVisibility()
       })
   }
 
@@ -366,7 +366,7 @@ class Map extends EventEmitter {
           c.isSelected = false
         }
 
-        c.drawActive(false) // Should be fine to pass in false for the force param
+        //c.updateVisibility()
       })
   }
 

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -340,7 +340,7 @@ class Map extends EventEmitter {
     this.carriers
       .forEach(c => {
         c.isSelected = false
-        //c.updateVisibility()
+        c.updateVisibility()
       })
   }
 
@@ -366,7 +366,7 @@ class Map extends EventEmitter {
           c.isSelected = false
         }
 
-        //c.updateVisibility()
+        c.updateVisibility()
       })
   }
 

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -18,7 +18,7 @@ class Star extends EventEmitter {
 
     this.isSelected = false
     this.isMouseOver = false
-    this.isInScanningRange = false // Default to false to force initial redraw
+    this.isInScanningRange = false // Default to false to  initial redraw
     this.zoomPercent = 0
   }
 
@@ -46,44 +46,39 @@ class Star extends EventEmitter {
     this.players = players
     this.carriers = carriers
     this.lightYearDistance = lightYearDistance
+    this.container.hitArea = new PIXI.Circle(this.data.location.x, this.data.location.y, 15)
   }
 
   draw () {
     // Note: The star may become visible/hidden due to changing scanning range.
-    // If a star is revealed or a star becomes masked then we want to force the entire
+    // If a star is revealed or a star becomes masked then we want to  the entire
     // star to be re-drawn.
-    let force = this.isInScanningRange !== this._isInScanningRange()
 
-    this.drawStar(force)
-    this.drawSpecialist(force)
-    // this.drawTerritory(force)
-    this.drawPlanets(force)
-    this.drawColour(force)
-    this.drawScanningRange(force)
-    this.drawHyperspaceRange(force)
-    this.drawName(force)
-    this.drawGarrison(force)
-    this.drawActive(force)
+    this.drawStar()
+    this.drawSpecialist()
+    // this.drawTerritory()
+    this.drawPlanets()
+    this.drawColour()
+    this.drawScanningRange()
+    this.drawHyperspaceRange()
+    this.drawName()
+    this.drawGarrison()
+    this.drawActive()
 
     this.isInScanningRange = this._isInScanningRange()
   }
 
-  drawActive (force) {
-    this.drawInfrastructure(force)
-    this.drawGarrison(force)
-    this.drawScanningRange(force)
-    this.drawHyperspaceRange(force)
+  drawActive () {
+    this.drawInfrastructure()
+    this.drawGarrison()
+    this.drawScanningRange()
+    this.drawHyperspaceRange()
   }
 
-  drawStar (force) {
-    if (force && this.graphics_star) {
-      this.container.removeChild(this.graphics_star)
-      this.graphics_star = null
-    }
+  drawStar () {
 
     if (!this.graphics_star) {
       this.graphics_star = new PIXI.Graphics()
-
       this.container.addChild(this.graphics_star)
     }
 
@@ -107,14 +102,13 @@ class Star extends EventEmitter {
       this.graphics_star.endFill()
     }
 
-    this.container.hitArea = new PIXI.Circle(this.data.location.x, this.data.location.y, 15)
   }
 
   drawSpecialist () {
     if (!this.hasSpecialist()) {
       return
     }
-    
+    //FIXME potential resource leak, should not create a new sprite every time
     let specialistTexture = TextureService.getSpecialistTexture(this.data.specialistId, false)
     let specialistSprite = new PIXI.Sprite(specialistTexture)
     specialistSprite.width = 3.5
@@ -129,15 +123,10 @@ class Star extends EventEmitter {
     return this.data.specialistId && this.data.specialistId > 0
   }
 
-  drawTerritory (force) {
-    if (force && this.graphics_territory) {
-      this.container.removeChild(this.graphics_territory)
-      this.graphics_territory = null
-    }
+  drawTerritory () {
 
     if (!this.graphics_territory) {
       this.graphics_territory = new PIXI.Graphics()
-
       this.container.addChild(this.graphics_territory)
     }
 
@@ -153,11 +142,7 @@ class Star extends EventEmitter {
     this.graphics_territory.endFill()
   }
 
-  drawPlanets (force) {
-    if (force && this.container_planets) {
-      this.container.removeChild(this.container_planets)
-      this.container_planets = null
-    }
+  drawPlanets () {
 
     if (!this.container_planets) {
       this.container_planets = new PIXI.Container()
@@ -235,15 +220,10 @@ class Star extends EventEmitter {
     return Math.floor(Math.random() * (1000 - 500 + 1) + 500) // Random number between 500 and 1000
   }
 
-  drawColour (force) {
-    if (force && this.graphics_colour) {
-      this.container.removeChild(this.graphics_colour)
-      this.graphics_colour = null
-    }
+  drawColour () {
 
     if (!this.graphics_colour) {
       this.graphics_colour = new PIXI.Graphics()
-
       this.container.addChild(this.graphics_colour)
     }
 
@@ -265,11 +245,7 @@ class Star extends EventEmitter {
     }
   }
 
-  drawName (force) {
-    if (force && this.text_name) {
-      this.container.removeChild(this.text_name)
-      this.text_name = null
-    }
+  drawName () {
 
     if (!this.text_name) {
       let style = TextureService.DEFAULT_FONT_STYLE
@@ -286,11 +262,7 @@ class Star extends EventEmitter {
     this.text_name.visible = this.isSelected || this.zoomPercent < 60
   }
 
-  drawGarrison (force) {
-    if (force && this.text_garrison) {
-      this.container.removeChild(this.text_garrison)
-      this.text_garrison = null
-    }
+  drawGarrison () {
 
     if (!this.text_garrison) {
       let style = TextureService.DEFAULT_FONT_STYLE
@@ -318,11 +290,7 @@ class Star extends EventEmitter {
     this.text_garrison.visible = this.data.infrastructure && (this.isSelected || this.isMouseOver || this.zoomPercent < 50)
   }
 
-  drawInfrastructure (force) {
-    if (force && this.text_infrastructure) {
-      this.container.removeChild(this.text_infrastructure)
-      this.text_infrastructure = null
-    }
+  drawInfrastructure () {
 
     if (!this.text_infrastructure) {
       let style = TextureService.DEFAULT_FONT_STYLE
@@ -345,11 +313,7 @@ class Star extends EventEmitter {
     }
   }
 
-  drawScanningRange (force) {
-    if (force && this.graphics_scanningRange) {
-      this.container.removeChild(this.graphics_scanningRange)
-      this.graphics_scanningRange = null
-    }
+  drawScanningRange () {
 
     if (!this.graphics_scanningRange) {
       this.graphics_scanningRange = new PIXI.Graphics()
@@ -387,11 +351,7 @@ class Star extends EventEmitter {
     this.container.zIndex = -1
   }
 
-  drawHyperspaceRange (force) {
-    if (force && this.graphics_hyperspaceRange) {
-      this.container.removeChild(this.graphics_hyperspaceRange)
-      this.graphics_hyperspaceRange = null
-    }
+  drawHyperspaceRange () {
 
     if (!this.graphics_hyperspaceRange) {
       this.graphics_hyperspaceRange = new PIXI.Graphics()
@@ -468,13 +428,11 @@ class Star extends EventEmitter {
 
   refreshZoom (zoomPercent) {
     this.zoomPercent = zoomPercent
-
-    // Note: Should never need to force a redraw when zooming
-    // so we should be fine to pass in false to the force draw parameter.
-    this.drawName(false)
-    this.drawGarrison(false)
-    this.drawInfrastructure(false)
-    this.drawPlanets(false)
+		return
+    this.drawName()
+    this.drawGarrison()
+    this.drawInfrastructure()
+    this.drawPlanets()
   }
 }
 

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -7,7 +7,6 @@ class Star extends EventEmitter {
     super()
 
     this.app = app
-
     this.container = new PIXI.Container()
     this.container.interactive = true
     this.container.buttonMode = true
@@ -63,6 +62,7 @@ class Star extends EventEmitter {
     this.drawHyperspaceRange()
     this.drawName()
     this.drawGarrison()
+    this.drawInfrastructure()
 
     this.isInScanningRange = this._isInScanningRange()
   }
@@ -255,48 +255,59 @@ class Star extends EventEmitter {
 
   drawGarrison () {
 
+    if ( this.text_garrison ) {
+      this.text_garrison.texture.destroy(true)
+      this.container.removeChild(this.text_garrison)
+      this.text_garrison = null
+    }
+
     if (!this.text_garrison) {
       let style = TextureService.DEFAULT_FONT_STYLE
       style.fontSize = 4
 
-      this.text_garrison = new PIXI.Text('', style)
+      let totalGarrison = (this.data.garrison || 0) + this._getStarCarrierGarrison()
+      let displayGarrison = ''
+
+      if (totalGarrison > 0) {
+        displayGarrison = totalGarrison
+      }
+      else if (this.data.garrison == null && this.data.infrastructure) { // Has no garrison but is in scanning range
+        displayGarrison = '???'
+      }
+
+      this.text_garrison = new PIXI.Text(displayGarrison, style)
       this.text_garrison.resolution = 10
+
+      this.text_garrison.x = this.data.location.x - (this.text_garrison.width / 2)
+      this.text_garrison.y = this.data.location.y + 12
 
       this.container.addChild(this.text_garrison)
     }
 
-    let totalGarrison = (this.data.garrison || 0) + this._getStarCarrierGarrison()
-    let displayGarrison = ''
-
-    if (totalGarrison > 0) {
-      displayGarrison = totalGarrison
-    }
-    else if (this.data.garrison == null && this.data.infrastructure) { // Has no garrison but is in scanning range
-      displayGarrison = '???'
-    }
-
-    this.text_garrison.text = displayGarrison
-    this.text_garrison.x = this.data.location.x - (this.text_garrison.width / 2)
-    this.text_garrison.y = this.data.location.y + 12
   }
 
   drawInfrastructure () {
 
-    if (!this.text_infrastructure) {
-      let style = TextureService.DEFAULT_FONT_STYLE
-      style.fontSize = 4
-
-      this.text_infrastructure = new PIXI.Text('', style)
-      this.text_infrastructure.resolution = 10
-
-      this.container.addChild(this.text_infrastructure)
+    if ( this.text_infrastructure ) {
+      this.text_infrastructure.texture.destroy(true)
+      this.container.removeChild(this.text_infrastructure)
+      this.text_infrastructure = null
     }
 
-    if (this.data.ownedByPlayerId && this._isInScanningRange()) {
-      this.text_infrastructure.text = `${this.data.infrastructure.economy} ${this.data.infrastructure.industry} ${this.data.infrastructure.science}`
-      this.text_infrastructure.x = this.data.location.x - (this.text_infrastructure.width / 2)
-      this.text_infrastructure.y = this.data.location.y - 12
+    if (!this.text_infrastructure) {
+      if (this.data.ownedByPlayerId && this._isInScanningRange()) {
+        let style = TextureService.DEFAULT_FONT_STYLE
+        style.fontSize = 4
+        let displayInfrastructure = `${this.data.infrastructure.economy} ${this.data.infrastructure.industry} ${this.data.infrastructure.science}`
 
+        this.text_infrastructure = new PIXI.Text(displayInfrastructure, style)
+        this.text_infrastructure.resolution = 10
+
+        this.text_infrastructure.x = this.data.location.x - (this.text_infrastructure.width / 2)
+        this.text_infrastructure.y = this.data.location.y - 12
+
+        this.container.addChild(this.text_infrastructure)
+      }
     }
 
   }
@@ -338,7 +349,6 @@ class Star extends EventEmitter {
 
     if (!this.graphics_hyperspaceRange) {
       this.graphics_hyperspaceRange = new PIXI.Graphics()
-
       this.container.addChild(this.graphics_hyperspaceRange)
     }
 

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -63,17 +63,10 @@ class Star extends EventEmitter {
     this.drawHyperspaceRange()
     this.drawName()
     this.drawGarrison()
-    this.drawActive()
 
     this.isInScanningRange = this._isInScanningRange()
   }
 
-  drawActive () {
-    this.drawInfrastructure()
-    this.drawGarrison()
-    this.drawScanningRange()
-    this.drawHyperspaceRange()
-  }
 
   drawStar () {
 
@@ -201,7 +194,6 @@ class Star extends EventEmitter {
       this.container.addChild(this.container_planets)
     }
 
-    this.container_planets.visible = this._isInScanningRange() && this.zoomPercent < 60
   }
 
   _getPlanetsCount () {
@@ -259,7 +251,6 @@ class Star extends EventEmitter {
       this.container.addChild(this.text_name)
     }
 
-    this.text_name.visible = this.isSelected || this.zoomPercent < 60
   }
 
   drawGarrison () {
@@ -287,7 +278,6 @@ class Star extends EventEmitter {
     this.text_garrison.text = displayGarrison
     this.text_garrison.x = this.data.location.x - (this.text_garrison.width / 2)
     this.text_garrison.y = this.data.location.y + 12
-    this.text_garrison.visible = this.data.infrastructure && (this.isSelected || this.isMouseOver || this.zoomPercent < 50)
   }
 
   drawInfrastructure () {
@@ -307,25 +297,18 @@ class Star extends EventEmitter {
       this.text_infrastructure.x = this.data.location.x - (this.text_infrastructure.width / 2)
       this.text_infrastructure.y = this.data.location.y - 12
 
-      this.text_infrastructure.visible = this.isMouseOver || this.isSelected || this.zoomPercent < 40
-    } else {
-      this.text_infrastructure.visible = false
     }
+
   }
 
   drawScanningRange () {
 
     if (!this.graphics_scanningRange) {
       this.graphics_scanningRange = new PIXI.Graphics()
-
       this.container.addChild(this.graphics_scanningRange)
     }
 
     this.graphics_scanningRange.clear()
-
-    if (!this.isSelected) {
-      return
-    }
 
     // Get the player who owns the star.
     let player = this._getStarPlayer()
@@ -363,7 +346,6 @@ class Star extends EventEmitter {
 
     if (!this.isSelected) {
       this.container.zIndex = 0
-      return
     }
 
     // Get the player who owns the star.
@@ -400,9 +382,27 @@ class Star extends EventEmitter {
 
       // Need to do this otherwise sometimes text gets highlighted.
       this.deselectAllText()
-
-      this.drawActive(false)
+      
+      if (this._getStarPlayer()) {
+        this.updateVisibility()
+      }
     }
+  }
+
+  updateVisibility() {
+
+    this.graphics_hyperspaceRange.visible = this.isSelected
+    this.graphics_scanningRange.visible = this.isSelected
+    this.text_name.visible = this.isSelected || this.zoomPercent < 60
+    this.container_planets.visible = this._isInScanningRange() && this.zoomPercent < 60
+
+    if (this.text_infrastructure) { // may not exist for stars out of range
+      this.text_infrastructure.visible = this.isMouseOver || this.isSelected || this.zoomPercent < 40
+    }
+    if (this.text_garrison) {
+      this.text_garrison.visible = this.data.infrastructure && (this.isSelected || this.isMouseOver || this.zoomPercent < 50)
+    }
+
   }
 
   deselectAllText () {
@@ -413,26 +413,18 @@ class Star extends EventEmitter {
   onMouseOver (e) {
     this.isMouseOver = true
 
-    this.drawActive(false)
-
     this.emit('onStarMouseOver', this.data)
   }
 
   onMouseOut (e) {
     this.isMouseOver = false
 
-    this.drawActive(false)
-
     this.emit('onStarMouseOut', this.data)
   }
 
   refreshZoom (zoomPercent) {
     this.zoomPercent = zoomPercent
-		return
-    this.drawName()
-    this.drawGarrison()
-    this.drawInfrastructure()
-    this.drawPlanets()
+    this.updateVisibility()
   }
 }
 


### PR DESCRIPTION
this branch does 2 things:
- fixes the resource leak by calling texture.destroy() everytime draw is called for some text: drawGarrison, drawResources, etc
- avoids calling the draw methods and calls updateVisibility() instead, since redrawing objects every time that something gets selected is wastefull. togling container.visible is enough

closes #348 