### PR TITLE
Viewport culling

### DIFF
--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -3,6 +3,9 @@ import EventEmitter from 'events'
 import TextureService from './texture'
 
 class Carrier extends EventEmitter {
+
+  static culling_margin = 16
+
   constructor () {
     super()
 
@@ -179,14 +182,21 @@ class Carrier extends EventEmitter {
 
   onTick( deltaTime, viewportData ) {
 
-   let deltax = Math.abs(viewportData.center.x - this.data.location.x)
-   let deltay = Math.abs(viewportData.center.y - this.data.location.y)
+   let deltax = Math.abs(viewportData.center.x - this.data.location.x) - Carrier.culling_margin
+   let deltay = Math.abs(viewportData.center.y - this.data.location.y) - Carrier.culling_margin
+
  
    if ( (deltax > viewportData.xradius) || (deltay > viewportData.yradius) ) {
-     this.container.visible = false
+     //cannot set parent container visibility, since waypoints lines stretch away from carrier location
+     // maybe put waypoints on its own container, since this piece of code should remain as small as possible
+     this.graphics_colour.visible = false
+     this.graphics_ship.visible = false
+     this.text_garrison.visible = false
    } 
    else {
-     this.container.visible = true
+     this.graphics_colour.visible = true
+     this.graphics_ship.visible = true
+     this.text_garrison.visible = true
      this.updateVisibility()
    }
 

--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -177,8 +177,19 @@ class Carrier extends EventEmitter {
     }
   }
 
-  onTick( deltaTime ) {
-   return
+  onTick( deltaTime, viewportData ) {
+
+   let deltax = Math.abs(viewportData.center.x - this.data.location.x)
+   let deltay = Math.abs(viewportData.center.y - this.data.location.y)
+ 
+   if ( (deltax > viewportData.xradius) || (deltay > viewportData.yradius) ) {
+     this.container.visible = false
+   } 
+   else {
+     this.container.visible = true
+     this.updateVisibility()
+   }
+
   }
 
   onClicked (e) {
@@ -224,7 +235,6 @@ class Carrier extends EventEmitter {
 
   refreshZoom (zoomPercent) {
     this.zoomPercent = zoomPercent
-    this.updateVisibility()
   }
 }
 

--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -177,6 +177,10 @@ class Carrier extends EventEmitter {
     }
   }
 
+  onTick( deltaTime ) {
+   return
+  }
+
   onClicked (e) {
     if (e && e.data && e.data.originalEvent && e.data.originalEvent.button === 2) {
       this.emit('onCarrierRightClicked', this.data)

--- a/client/src/game/container.js
+++ b/client/src/game/container.js
@@ -43,7 +43,9 @@ class GameContainer {
     })
     this.app.ticker.add( this.onTick.bind(this) )
 
-    this.app.ticker.add( this.calcFPS.bind(this) )
+    if ( process.env.NODE_ENV == 'development') {
+      this.app.ticker.add( this.calcFPS.bind(this) )
+    }
 
     // create viewport
     this.viewport = new Viewport({

--- a/client/src/game/container.js
+++ b/client/src/game/container.js
@@ -26,6 +26,7 @@ class GameContainer {
       resolution: window.devicePixelRatio || 1,
       autoResize: true
     })
+    this.app.ticker.add( this.onTick.bind(this) )
 
     // create viewport
     this.viewport = new Viewport({
@@ -142,6 +143,10 @@ class GameContainer {
     if (!game.galaxy.stars.length) { return 0 }
 
     return game.galaxy.stars.sort((a, b) => b.location.y - a.location.y)[0].location.y
+  }
+
+  onTick( deltaTime ) {
+    this.map.onTick( deltaTime )
   }
 
   onViewportZoomed (e) {

--- a/client/src/game/container.js
+++ b/client/src/game/container.js
@@ -5,6 +5,21 @@ import Map from './map'
 class GameContainer {
   constructor () {
     PIXI.settings.SORTABLE_CHILDREN = true
+    this.frames = 0
+    this.dtAccum = 0
+  }
+
+  calcFPS(deltaTime) {
+    //assumes PIXI ticker is set to 60(default)
+    this.frames++
+    this.dtAccum += deltaTime/60.0
+    if (this.frames >= 60*5) {
+      let avg = this.dtAccum/(60.0*5.0)
+      console.log( 'avg dt: '+avg )
+      console.log( 'avg fps: '+1000.0/(1000.0*avg) )
+      this.frames = 0
+      this.dtAccum = 0
+    }
   }
 
   setupApp () {
@@ -27,6 +42,8 @@ class GameContainer {
       autoResize: true
     })
     this.app.ticker.add( this.onTick.bind(this) )
+
+    this.app.ticker.add( this.calcFPS.bind(this) )
 
     // create viewport
     this.viewport = new Viewport({

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -370,6 +370,11 @@ class Map extends EventEmitter {
       })
   }
 
+  onTick( deltaTime ) {
+    this.stars.forEach(s => s.onTick(deltaTime))
+    this.carriers.forEach(c => c.refreshZoom(deltaTime))
+  }
+
   onViewportPointerDown(e) {
     //need Object.assign, wich is weird since pixie says it creates a new point each time
     this.lastPointerDownPosition = Object.assign({}, e.data.global)

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -371,8 +371,26 @@ class Map extends EventEmitter {
   }
 
   onTick( deltaTime ) {
-    this.stars.forEach(s => s.onTick(deltaTime))
-    this.carriers.forEach(c => c.refreshZoom(deltaTime))
+
+    let viewportWidth = gameContainer.viewport.right - gameContainer.viewport.left
+    let viewportHeight = gameContainer.viewport.bottom - gameContainer.viewport.top
+    
+    let viewportXRadius = viewportWidth/2.0
+    let viewportYRadius = viewportHeight/2.0
+    
+    let viewportCenter = gameContainer.viewport.center
+
+    let zoomPercent = (gameContainer.viewport.screenWidth/viewportWidth)*100
+
+    let viewportData = {
+      center: viewportCenter,
+      xradius: viewportXRadius,
+      yradius: viewportYRadius
+    }
+
+    this.stars.forEach(s => s.onTick(deltaTime, viewportData))
+    this.carriers.forEach(c => c.refreshZoom(deltaTime, viewportData))
+
   }
 
   onViewportPointerDown(e) {

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -389,7 +389,7 @@ class Map extends EventEmitter {
     }
 
     this.stars.forEach(s => s.onTick(deltaTime, viewportData))
-    this.carriers.forEach(c => c.refreshZoom(deltaTime, viewportData))
+    this.carriers.forEach(c => c.onTick(deltaTime, viewportData))
 
   }
 

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -382,6 +382,10 @@ class Star extends EventEmitter {
     this.container.zIndex = -1
   }
 
+  onTick( deltaTime ) {
+   return
+  }
+
   onClicked (e) {
     if (e && e.data && e.data.originalEvent && e.data.originalEvent.button === 2) {
       this.emit('onStarRightClicked', this.data)

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -382,8 +382,19 @@ class Star extends EventEmitter {
     this.container.zIndex = -1
   }
 
-  onTick( deltaTime ) {
-   return
+  onTick( deltaTime, viewportData ) {
+
+   let deltax = Math.abs(viewportData.center.x - this.data.location.x)
+   let deltay = Math.abs(viewportData.center.y - this.data.location.y)
+ 
+   if ( (deltax > viewportData.xradius) || (deltay > viewportData.yradius) ) {
+     this.container.visible = false
+   } 
+   else {
+     this.container.visible = true
+     this.updateVisibility()
+   }
+
   }
 
   onClicked (e) {
@@ -438,7 +449,6 @@ class Star extends EventEmitter {
 
   refreshZoom (zoomPercent) {
     this.zoomPercent = zoomPercent
-    this.updateVisibility()
   }
 }
 

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -3,6 +3,9 @@ import EventEmitter from 'events'
 import TextureService from './texture'
 
 class Star extends EventEmitter {
+
+  static culling_margin = 16
+
   constructor (app) {
     super()
 
@@ -384,8 +387,8 @@ class Star extends EventEmitter {
 
   onTick( deltaTime, viewportData ) {
 
-   let deltax = Math.abs(viewportData.center.x - this.data.location.x)
-   let deltay = Math.abs(viewportData.center.y - this.data.location.y)
+   let deltax = Math.abs(viewportData.center.x - this.data.location.x) - Star.culling_margin
+   let deltay = Math.abs(viewportData.center.y - this.data.location.y) - Star.culling_margin
  
    if ( (deltax > viewportData.xradius) || (deltay > viewportData.yradius) ) {
      this.container.visible = false


### PR DESCRIPTION
this pr implements viewport culling. it skips drawing carriers and stars outside of the viewport. waypoint lines are not culled.
i made some tests in maps created with stress-test branch( to distribute all stars to the players ):

fps with/without culling:

@ zoom level enough to display infrastructure and garison
| stars  | with  | without |
|---| -------| ---------- |
8*30| 59+ | 59+ |
16*30| 59+| ~39 |

@ smallest zoom level but before territories are drawn 
| stars  | with  | without |
|---| -------| ---------- |
8*30| 59+ | 59+ |
16*30| ~58| ~56 |

- since framerate is capped, it was impossible to measure more than 59-60 fps
- tests on chromim-browser