### PR TITLE
Fix to the bulk exploit

### DIFF
--- a/server/services/starUpgrade.js
+++ b/server/services/starUpgrade.js
@@ -351,7 +351,7 @@ module.exports = class StarUpgradeService extends EventEmitter {
     async upgradeBulk(game, player, infrastructureType, amount) {
         // Check that the amount the player wants to spend isn't more than the amount he has
         if(player.credits < amount) {
-            return null;
+            throw new ValidationError(`The player does not own enough credits to afford to bulk upgrade.`);
         }
         let upgradeSummary = await this.generateUpgradeBulkReport(game, player, infrastructureType, amount);
 

--- a/server/services/starUpgrade.js
+++ b/server/services/starUpgrade.js
@@ -349,6 +349,10 @@ module.exports = class StarUpgradeService extends EventEmitter {
     }
 
     async upgradeBulk(game, player, infrastructureType, amount) {
+        // Check that the amount the player wants to spend isn't more than the amount he has
+        if(player.credits < amount) {
+            return null;
+        }
         let upgradeSummary = await this.generateUpgradeBulkReport(game, player, infrastructureType, amount);
 
         // Generate the DB writes for all the stars to upgrade, including deducting the credits


### PR DESCRIPTION
- Due to recent changes there no longer was any check which prevented the function starUpgrade.upgradeBulk to run even if the `amount` asked was higher than `player.credits`.
- The check that prevents players from upgrading stars they cannot afford to upgrade individually is bypassed by starUpgrade.upgradeBulk, which caused the error that we know.