### PR TITLE
Fix npm commands in development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The client uses the following tech:
 4. `npm install` in both `client/` and `server/` directories.
 5. Create a `.env` file in `server/` (See `.env.example`).
 6. Create a `.env` file in `client/` (See `.env.example`).
-7. `npm start-jobs` in `server/` to start the automated jobs.
-8. `npm start-api` in `server/` to start the API.
+7. `npm run start-jobs` in `server/` to start the automated jobs.
+8. `npm run start-api` in `server/` to start the API.
 9. `npm run serve` in `client/` to start the client application.
 10. Browse to the site locally (default [http://localhost:8080](http://localhost:8080)).
 


### PR DESCRIPTION
Fixed the npm commands in the development section of the README (`run` was missing)