### PR TITLE
Fix Raider specialist weapons value #571

### DIFF
--- a/server/config/game/specialists.json
+++ b/server/config/game/specialists.json
@@ -136,7 +136,7 @@
             "modifiers": {
                 "local": {
                     "speed": 2,
-                    "weapons": -1
+                    "weapons": -2
                 },
                 "special": {
                     "starCaptureRewardMultiplier": 2


### PR DESCRIPTION
Fixes the Raider Specialists weapons modifier as outlined in issue #571 