### PR TITLE
Carrier renaming

### DIFF
--- a/client/src/components/game/carrier/CarrierDetail.vue
+++ b/client/src/components/game/carrier/CarrierDetail.vue
@@ -1,7 +1,8 @@
 <template>
 <div class="menu-page container" v-if="carrier">
     <menu-title :title="carrier.name" @onCloseRequested="onCloseRequested">
-      <button @click="viewOnMap" class="btn btn-sm btn-info"><i class="fas fa-eye"></i></button>
+      <button @click="onCarrierRenameRequested" class="btn btn-sm btn-success">Rename <i class="fas fa-pencil-alt"></i></button>
+      <button @click="viewOnMap" class="btn btn-sm btn-info ml-1"><i class="fas fa-eye"></i></button>
     </menu-title>
 
     <div class="row bg-secondary">
@@ -240,6 +241,12 @@ export default {
     },
     onViewCompareIntelRequested (e) {
       this.$emit('onViewCompareIntelRequested', e)
+    },
+    onCarrierRenameRequested (e) {
+      this.$emit('onCarrierRenameRequested', {
+        carrierId: this.carrierId,
+        originalName: this.carrier.name
+      })
     },
     onViewHireCarrierSpecialistRequested (e) {
       this.$emit('onViewHireCarrierSpecialistRequested', this.carrier._id)

--- a/client/src/components/game/carrier/CarrierDetail.vue
+++ b/client/src/components/game/carrier/CarrierDetail.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="menu-page container" v-if="carrier">
     <menu-title :title="carrier.name" @onCloseRequested="onCloseRequested">
-      <button @click="onCarrierRenameRequested" class="btn btn-sm btn-success">Rename <i class="fas fa-pencil-alt"></i></button>
+      <button @click="onCarrierRenameRequested" class="btn btn-sm btn-success"><i class="fas fa-pencil-alt"></i></button>
       <button @click="viewOnMap" class="btn btn-sm btn-info ml-1"><i class="fas fa-eye"></i></button>
     </menu-title>
 

--- a/client/src/components/game/carrier/CarrierDetail.vue
+++ b/client/src/components/game/carrier/CarrierDetail.vue
@@ -243,10 +243,7 @@ export default {
       this.$emit('onViewCompareIntelRequested', e)
     },
     onCarrierRenameRequested (e) {
-      this.$emit('onCarrierRenameRequested', {
-        carrierId: this.carrierId,
-        originalName: this.carrier.name
-      })
+      this.$emit('onCarrierRenameRequested', this.carrier._id)
     },
     onViewHireCarrierSpecialistRequested (e) {
       this.$emit('onViewHireCarrierSpecialistRequested', this.carrier._id)

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -1,12 +1,12 @@
 <template>
 <div class="menu-page container" v-if="carrierId">
-  <menu-title :title="originalName" @onCloseRequested="onCloseRequested" />
+  <menu-title :title="originalName" @onCloseRequested="onCloseRequested" :disabled="isSaving" />
   <div class="row bg-secondary pl-2 pt-2 pb-2">
     <strong>Name:</strong>
     <input class="ml-2 mr-2 auto-width" v-model="currentName" type="text" />
   </div>
   <div class="row pt-2 pb-2">
-    <button class="btn btn-sm btn-success ml-1" @click="doRename">
+    <button class="btn btn-sm btn-success ml-1" @click="doRename" :disabled="isSaving">
       <i class="fas fa-save"></i>
       <span class="ml-1 d-none d-sm-inline-block">Save</span>
     </button>
@@ -16,10 +16,11 @@
 
 <script>
 import MenuTitle from '../MenuTitle'
+import CarrierApiService from '../../../services/api/carrier'
 
 export default {
   components: {
-    'menu-title': MenuTitle,
+    'menu-title': MenuTitle
   },
   props: {
     carrierId: String,
@@ -27,6 +28,7 @@ export default {
   },
   data () {
     return {
+      isSaving: false,
       currentName: this.originalName
     }
   },
@@ -34,8 +36,15 @@ export default {
     onCloseRequested (e) {
       this.$emit('onCloseRequested', e)
     },
-    doRename (e) {
-
+    async doRename (e) {
+      this.isSaving = true
+      try {
+        await CarrierApiService.renameCarrier(this.$store.state.game._id, this.carrierId, this.currentName)
+        this.onCloseRequested(e)
+      } catch (err) {
+        console.error(err)
+      }
+      this.isSaving = false
     }
   }
 }

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -1,11 +1,11 @@
 <template>
 <div class="menu-page container" v-if="carrierId">
   <menu-title :title="originalName" @onCloseRequested="onCloseRequested" />
-  <div class="row bg-secondary">
+  <div class="row bg-secondary pl-2 pt-2 pb-2">
     <strong>Name:</strong>
-    <input v-model="currentName" type="text" />
+    <input class="ml-2 mr-2 auto-width" v-model="currentName" type="text" />
   </div>
-  <div class="row">
+  <div class="row pt-2 pb-2">
     <button class="btn btn-sm btn-success ml-1" @click="doRename">
       <i class="fas fa-save"></i>
       <span class="ml-1 d-none d-sm-inline-block">Save</span>

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -17,6 +17,7 @@
 <script>
 import MenuTitle from '../MenuTitle'
 import CarrierApiService from '../../../services/api/carrier'
+import gameHelper from '../../../services/gameHelper'
 
 export default {
   components: {
@@ -46,6 +47,8 @@ export default {
       this.isSaving = true
       try {
         await CarrierApiService.renameCarrier(this.$store.state.game._id, this.carrierId, this.currentName)
+        const carrier = gameHelper.getCarrierById(this.$store.state.game, this.carrierId);
+        carrier.name = this.currentName;
         this.$toasted.show(`Carrier renamed to ${this.currentName}.`)
         this.onCloseRequested(e)
       } catch (err) {

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -1,0 +1,42 @@
+<template>
+<div class="menu-page container" v-if="carrierId">
+  <menu-title :title="originalName" @onCloseRequested="onCloseRequested" />
+  <div class="row bg-secondary">
+    <strong>Name:</strong>
+    <input v-model="currentName" type="text" />
+  </div>
+  <div class="row">
+    <button class="btn btn-sm btn-success ml-1" @click="doRename">
+      <i class="fas fa-save"></i>
+      <span class="ml-1 d-none d-sm-inline-block">Save</span>
+    </button>
+  </div>
+</div>
+</template>
+
+<script>
+import MenuTitle from '../MenuTitle'
+
+export default {
+  components: {
+    'menu-title': MenuTitle,
+  },
+  props: {
+    carrierId: String,
+    originalName: String
+  },
+  data () {
+    return {
+      currentName: this.originalName
+    }
+  },
+  methods: {
+    onCloseRequested (e) {
+      this.$emit('onCloseRequested', e)
+    },
+    doRename (e) {
+
+    }
+  }
+}
+</script>

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -3,10 +3,10 @@
   <menu-title :title="originalName" @onCloseRequested="onCloseRequested" :disabled="isSaving" />
   <div class="row bg-secondary pl-2 pt-2 pb-2">
     <strong>Name:</strong>
-    <input class="ml-2 mr-2 auto-width" v-model="currentName" type="text" />
+    <input class="ml-2 mr-2 auto-width" v-model="currentName" type="text" maxlength="30" />
   </div>
   <div class="row pt-2 pb-2">
-    <button class="btn btn-sm btn-success ml-1" @click="doRename" :disabled="isSaving">
+    <button class="btn btn-sm btn-success ml-1" @click="doRename" :disabled="isSaving || isNameInvalid">
       <i class="fas fa-save"></i>
       <span class="ml-1 d-none d-sm-inline-block">Save</span>
     </button>
@@ -30,6 +30,12 @@ export default {
     return {
       isSaving: false,
       currentName: this.originalName
+    }
+  },
+  computed: {
+    isNameInvalid () {
+      const trimmed = this.currentName.trim();
+      return trimmed.length < 4 || trimmed.length > 30;
     }
   },
   methods: {

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -40,6 +40,7 @@ export default {
       this.isSaving = true
       try {
         await CarrierApiService.renameCarrier(this.$store.state.game._id, this.carrierId, this.currentName)
+        this.$toasted.show(`Carrier renamed to ${this.currentName}.`)
         this.onCloseRequested(e)
       } catch (err) {
         console.error(err)

--- a/client/src/components/game/carrier/CarrierRename.vue
+++ b/client/src/components/game/carrier/CarrierRename.vue
@@ -1,16 +1,28 @@
 <template>
 <div class="menu-page container" v-if="carrierId">
-  <menu-title :title="originalName" @onCloseRequested="onCloseRequested" :disabled="isSaving" />
-  <div class="row bg-secondary pl-2 pt-2 pb-2">
-    <strong>Name:</strong>
-    <input class="ml-2 mr-2 auto-width" v-model="currentName" type="text" maxlength="30" />
-  </div>
-  <div class="row pt-2 pb-2">
-    <button class="btn btn-sm btn-success ml-1" @click="doRename" :disabled="isSaving || isNameInvalid">
-      <i class="fas fa-save"></i>
-      <span class="ml-1 d-none d-sm-inline-block">Save</span>
-    </button>
-  </div>
+  <menu-title title="Rename Carrier" @onCloseRequested="onCloseRequested" :disabled="isSaving">
+    <button @click="viewOnMap" class="btn btn-sm btn-info ml-1"><i class="fas fa-eye"></i></button>
+  </menu-title>
+
+  <form @submit="doRename">
+    <div class="form-group">
+      <input type="text" class="form-control" id="name" placeholder="Enter a new carrier name" v-model="currentName" minlength="4" maxlength="30" @change="onNameChanged">
+    </div>
+    <div class="form-group row pb-2 pt-2 bg-secondary">
+      <div class="col">
+        <button type="button" class="btn btn-sm btn-primary" :disabled="isSaving" @click="onOpenCarrierDetailRequested">
+          <i class="fas fa-arrow-left"></i>
+          Back to Carrier
+        </button>
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-success" :disabled="isSaving || isNameInvalid">
+          <i class="fas fa-save"></i>
+          Rename
+        </button>
+      </div>
+    </div>
+  </form>
 </div>
 </template>
 
@@ -18,42 +30,63 @@
 import MenuTitle from '../MenuTitle'
 import CarrierApiService from '../../../services/api/carrier'
 import gameHelper from '../../../services/gameHelper'
+import GameContainer from '../../../game/container'
 
 export default {
   components: {
     'menu-title': MenuTitle
   },
   props: {
-    carrierId: String,
-    originalName: String
+    carrierId: String
   },
   data () {
     return {
+      carrier: null,
       isSaving: false,
-      currentName: this.originalName
+      currentName: ''
     }
+  },
+  mounted () {
+    this.carrier = gameHelper.getCarrierById(this.$store.state.game, this.carrierId)
+    this.currentName = this.carrier.name
   },
   computed: {
     isNameInvalid () {
-      const trimmed = this.currentName.trim();
-      return trimmed.length < 4 || trimmed.length > 30;
+      const trimmed = this.currentName.trim()
+
+      return trimmed.length < 4 || trimmed.length > 30
     }
   },
   methods: {
     onCloseRequested (e) {
       this.$emit('onCloseRequested', e)
     },
+    onOpenCarrierDetailRequested (e) {
+      this.$emit('onOpenCarrierDetailRequested', this.carrierId)
+    },
+    onNameChanged (e) {
+      this.currentName = this.currentName.trim().replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();})
+    },
+    viewOnMap (e) {
+      GameContainer.map.panToCarrier(this.carrier)
+    },
     async doRename (e) {
+      e.preventDefault()
+
       this.isSaving = true
+
       try {
         await CarrierApiService.renameCarrier(this.$store.state.game._id, this.carrierId, this.currentName)
-        const carrier = gameHelper.getCarrierById(this.$store.state.game, this.carrierId);
-        carrier.name = this.currentName;
+
+        gameHelper.getCarrierById(this.$store.state.game, this.carrierId).name = this.currentName
+
         this.$toasted.show(`Carrier renamed to ${this.currentName}.`)
+
         this.onCloseRequested(e)
       } catch (err) {
         console.error(err)
       }
+
       this.isSaving = false
     }
   }

--- a/client/src/components/game/menu/MainBar.vue
+++ b/client/src/components/game/menu/MainBar.vue
@@ -54,8 +54,8 @@
         @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"/>
       <carrier-rename v-if="menuState == MENU_STATES.CARRIER_RENAME"
         @onCloseRequested="onCloseRequested"
-        :carrierId="menuArguments.carrierId"
-        :originalName="menuArguments.originalName" />
+        @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"
+        :carrierId="menuArguments" />
       <combat-calculator v-if="menuState == MENU_STATES.COMBAT_CALCULATOR" @onCloseRequested="onCloseRequested"/>
       <ship-transfer v-if="menuState == MENU_STATES.SHIP_TRANSFER" @onCloseRequested="onCloseRequested" :carrierId="menuArguments" @onShipsTransferred="onShipsTransferred" @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"/>
       <build-carrier v-if="menuState == MENU_STATES.BUILD_CARRIER"

--- a/client/src/components/game/menu/MainBar.vue
+++ b/client/src/components/game/menu/MainBar.vue
@@ -32,7 +32,8 @@
         @onViewHireStarSpecialistRequested="onViewHireStarSpecialistRequested"
         @onBuildCarrierRequested="onBuildCarrierRequested"
         @onShipTransferRequested="onShipTransferRequested"/>
-      <carrier-detail v-if="menuState == MENU_STATES.CARRIER_DETAIL" @onCloseRequested="onCloseRequested" :carrierId="menuArguments" :key="menuArguments"
+      <carrier-detail v-if="menuState == MENU_STATES.CARRIER_DETAIL" 
+        @onCloseRequested="onCloseRequested" :carrierId="menuArguments" :key="menuArguments"
         @onShipTransferRequested="onShipTransferRequested"
         @onEditWaypointsRequested="onEditWaypointsRequested"
         @onEditWaypointRequested="onEditWaypointRequested"
@@ -40,7 +41,8 @@
         @onOpenStarDetailRequested="onOpenStarDetailRequested"
         @onOpenPlayerDetailRequested="onOpenPlayerDetailRequested"
         @onViewCompareIntelRequested="onViewCompareIntelRequested"
-        @onViewHireCarrierSpecialistRequested="onViewHireCarrierSpecialistRequested"/>
+        @onViewHireCarrierSpecialistRequested="onViewHireCarrierSpecialistRequested"
+        @onCarrierRenameRequested="onCarrierRenameRequested" />
       <carrier-waypoints v-if="menuState == MENU_STATES.CARRIER_WAYPOINTS"
         @onCloseRequested="onCloseRequested" :carrierId="menuArguments"
         @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"
@@ -50,6 +52,10 @@
         :carrierId="menuArguments.carrierId"
         :waypoint="menuArguments.waypoint"
         @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"/>
+      <carrier-rename v-if="menuState == MENU_STATES.CARRIER_RENAME"
+        @onCloseRequested="onCloseRequested"
+        :carrierId="menuArguments.carrierId"
+        :originalName="menuArguments.originalName" />
       <combat-calculator v-if="menuState == MENU_STATES.COMBAT_CALCULATOR" @onCloseRequested="onCloseRequested"/>
       <ship-transfer v-if="menuState == MENU_STATES.SHIP_TRANSFER" @onCloseRequested="onCloseRequested" :carrierId="menuArguments" @onShipsTransferred="onShipsTransferred" @onOpenCarrierDetailRequested="onOpenCarrierDetailRequested"/>
       <build-carrier v-if="menuState == MENU_STATES.BUILD_CARRIER"
@@ -123,6 +129,7 @@ import StarDetailVue from '../star/StarDetail.vue'
 import CarrierDetailVue from '../carrier/CarrierDetail.vue'
 import CarrierWaypointsVue from '../carrier/CarrierWaypoints.vue'
 import CarrierWaypointVue from '../carrier/CarrierWaypoint.vue'
+import CarrierRenameVue from '../carrier/CarrierRename.vue'
 import ShipTransferVue from '../carrier/ShipTransfer.vue'
 import BuildCarrierVue from '../carrier/BuildCarrier.vue'
 import InboxVue from '../inbox/Inbox.vue'
@@ -156,6 +163,7 @@ export default {
     'carrier-detail': CarrierDetailVue,
     'carrier-waypoints': CarrierWaypointsVue,
     'carrier-waypoint': CarrierWaypointVue,
+    'carrier-rename': CarrierRenameVue,
     'combat-calculator': CombatCalculatorVue,
     'ship-transfer': ShipTransferVue,
     'build-carrier': BuildCarrierVue,
@@ -237,6 +245,9 @@ export default {
     },
     onBuildCarrierRequested (e) {
       this.changeMenuState(MENU_STATES.BUILD_CARRIER, e)
+    },
+    onCarrierRenameRequested (e) {
+      this.changeMenuState(MENU_STATES.CARRIER_RENAME, e)
     },
     onCreateNewConversationRequested (e) {
       this.changeMenuState(MENU_STATES.CREATE_CONVERSATION, e)

--- a/client/src/services/api/carrier.js
+++ b/client/src/services/api/carrier.js
@@ -3,7 +3,7 @@ import BaseApiService from './base'
 
 class CarrierService extends BaseApiService {
   renameCarrier (gameId, carrierId, name) {
-    return axios.post(this.BASE_URL + 'game/' + gameId + '/carrier/' + carrierId + '/rename', { 
+    return axios.patch(this.BASE_URL + 'game/' + gameId + '/carrier/' + carrierId + '/rename', { 
       name
     }, { withCredentials: true })
   }

--- a/client/src/services/api/carrier.js
+++ b/client/src/services/api/carrier.js
@@ -2,6 +2,12 @@ import axios from 'axios'
 import BaseApiService from './base'
 
 class CarrierService extends BaseApiService {
+  renameCarrier (gameId, carrierId, name) {
+    return axios.put(this.BASE_URL + 'game/' + gameId + '/carrier/' + carrierId + '/rename', { 
+      name
+    }, { withCredentials: true })
+  }
+
   saveWaypoints (gameId, carrierId, waypoints, looped) {
     return axios.put(this.BASE_URL + 'game/' + gameId + '/carrier/' + carrierId + '/waypoints', {
       waypoints,

--- a/client/src/services/api/carrier.js
+++ b/client/src/services/api/carrier.js
@@ -3,7 +3,7 @@ import BaseApiService from './base'
 
 class CarrierService extends BaseApiService {
   renameCarrier (gameId, carrierId, name) {
-    return axios.put(this.BASE_URL + 'game/' + gameId + '/carrier/' + carrierId + '/rename', { 
+    return axios.post(this.BASE_URL + 'game/' + gameId + '/carrier/' + carrierId + '/rename', { 
       name
     }, { withCredentials: true })
   }

--- a/server/api/game/carrier.js
+++ b/server/api/game/carrier.js
@@ -123,7 +123,7 @@ module.exports = (router, io, container) => {
         }
     }, middleware.handleError);
 
-    router.put('/api/game/:gameId/carrier/rename', middleware.authenticate, middleware.loadGame, middleware.validateGameLocked, middleware.validateGameNotFinished, middleware.loadPlayer, middleware.validateUndefeatedPlayer, async (req, res, next) => {
+    router.post('/api/game/:gameId/carrier/:carrierId/rename', middleware.authenticate, middleware.loadGame, middleware.validateGameLocked, middleware.validateGameNotFinished, middleware.loadPlayer, middleware.validateUndefeatedPlayer, async (req, res, next) => {
         try {
             await container.carrierService.renameCarrier(
                 req.game,

--- a/server/api/game/carrier.js
+++ b/server/api/game/carrier.js
@@ -123,7 +123,7 @@ module.exports = (router, io, container) => {
         }
     }, middleware.handleError);
 
-    router.post('/api/game/:gameId/carrier/:carrierId/rename', middleware.authenticate, middleware.loadGame, middleware.validateGameLocked, middleware.validateGameNotFinished, middleware.loadPlayer, middleware.validateUndefeatedPlayer, async (req, res, next) => {
+    router.patch('/api/game/:gameId/carrier/:carrierId/rename', middleware.authenticate, middleware.loadGame, middleware.validateGameLocked, middleware.validateGameNotFinished, middleware.loadPlayer, middleware.validateUndefeatedPlayer, async (req, res, next) => {
         try {
             await container.carrierService.rename(
                 req.game,

--- a/server/api/game/carrier.js
+++ b/server/api/game/carrier.js
@@ -123,6 +123,20 @@ module.exports = (router, io, container) => {
         }
     }, middleware.handleError);
 
+    router.put('/api/game/:gameId/carrier/rename', middleware.authenticate, middleware.loadGame, middleware.validateGameLocked, middleware.validateGameNotFinished, middleware.loadPlayer, middleware.validateUndefeatedPlayer, async (req, res, next) => {
+        try {
+            await container.carrierService.renameCarrier(
+                req.game,
+                req.player,
+                req.params.carrierId,
+                 req.query.name);
+
+            return res.sendStatus(200);
+        } catch (err) {
+            return next(err);
+        }
+    }, middleware.handleError);
+
     router.post('/api/game/:gameId/carrier/calculateCombat', middleware.authenticate, middleware.loadGameLean, middleware.validateGameLocked, (req, res, next) => {
         let errors = [];
 

--- a/server/api/game/carrier.js
+++ b/server/api/game/carrier.js
@@ -129,7 +129,7 @@ module.exports = (router, io, container) => {
                 req.game,
                 req.player,
                 req.params.carrierId,
-                 req.query.name);
+                req.body.name);
 
             return res.sendStatus(200);
         } catch (err) {

--- a/server/api/game/carrier.js
+++ b/server/api/game/carrier.js
@@ -125,7 +125,7 @@ module.exports = (router, io, container) => {
 
     router.post('/api/game/:gameId/carrier/:carrierId/rename', middleware.authenticate, middleware.loadGame, middleware.validateGameLocked, middleware.validateGameNotFinished, middleware.loadPlayer, middleware.validateUndefeatedPlayer, async (req, res, next) => {
         try {
-            await container.carrierService.renameCarrier(
+            await container.carrierService.rename(
                 req.game,
                 req.player,
                 req.params.carrierId,

--- a/server/loaders/container.js
+++ b/server/loaders/container.js
@@ -76,7 +76,7 @@ module.exports = (io) => {
     const specialistService = new SpecialistService();
     const technologyService = new TechnologyService(specialistService);
     const starService = new StarService(GameModel, randomService, nameService, distanceService, starDistanceService, technologyService, specialistService, userService);
-    const carrierService = new CarrierService(achievementService, distanceService, starService, technologyService, specialistService);
+    const carrierService = new CarrierService(GameModel, achievementService, distanceService, starService, technologyService, specialistService);
     const combatService = new CombatService(technologyService, specialistService);
     const circularMapService = new CircularMapService(randomService, starService, starDistanceService, distanceService);
     const circularBalancedMapService = new CircularBalancedMapService(randomService, starService, starDistanceService, distanceService);

--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -258,6 +258,10 @@ module.exports = class CarrierService {
             throw new ValidationError('Name was not passed');
         }
 
+        if (name.length > 30) {
+            throw new ValidationError('Name was too long')
+        }
+
         if (!carrier.ownedByPlayerId.equals(player._id)) {
             throw new ValidationError(`Cannot rename carrier, you are not its owner.`);
         }

--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -250,6 +250,14 @@ module.exports = class CarrierService {
     async rename(game, player, carrierId, name) {
         let carrier = this.getById(game, carrierId);
 
+        if (!carrier) {
+            throw new ValidationError('Carrier does not exist');
+        }
+
+        if (!name) {
+            throw new ValidationError('Name was not passed');
+        }
+
         if (!carrier.ownedByPlayerId.equals(player._id)) {
             throw new ValidationError(`Cannot rename carrier, you are not its owner.`);
         }

--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -247,6 +247,18 @@ module.exports = class CarrierService {
         await game.save();
     }
 
+    async rename(game, player, carrierId, name) {
+        let carrier = this.getById(game, carrierId);
+
+        if (!carrier.ownedByPlayerId.equals(player._id)) {
+            throw new ValidationError(`Cannot rename carrier, you are not its owner.`);
+        }
+
+        carrier.name = name.trim();
+
+        await game.save();
+    }
+
     async transferGift(game, gameUsers, star, carrier) {
         if (!star.ownedByPlayerId) {
             throw new ValidationError(`Cannot transfer ownership of a gifted carrier to this star, no player owns the star.`);


### PR DESCRIPTION
Adds a menu for renaming a carrier. Currently allows multiple carriers with the same name because this should not cause problems, except for self-inflicted confusion.