### PR TITLE
Enable antialias flag on PIXI

### DIFF
--- a/client/src/game/container.js
+++ b/client/src/game/container.js
@@ -44,6 +44,7 @@ class GameContainer {
       height: window.innerHeight, // window.innerHeight,
       backgroundColor: 0x000000, // black hexadecimal
       resolution: window.devicePixelRatio || 1,
+      antialias: true,
       autoResize: true
     })
 


### PR DESCRIPTION
I noticed PIXI didn't have its antialias feature enabled so I enabled it. The difference is definitely noticable.

I don't think this should cause major performance issues but best test it on a mobile device with a lot of carriers on-screen.