### PR TITLE
Updated zoom mechanics

### DIFF
--- a/client/src/game/carrier.js
+++ b/client/src/game/carrier.js
@@ -444,8 +444,8 @@ class Carrier extends EventEmitter {
   updateVisibility() {
     let displayTextZoom = 150
 
-    this.graphics_ship.visible = !this.data.orbiting && !this.hasSpecialist()
-    this.text_garrison.visible = !this.data.orbiting && (this.zoomPercent > displayTextZoom || (this.isSelected && this.zoomPercent > displayTextZoom ) || (this.isMouseOver && this.zoomPercent > displayTextZoom))
+    if (this.graphics_ship) this.graphics_ship.visible = !this.data.orbiting && !this.hasSpecialist()
+    if (this.text_garrison) this.text_garrison.visible = !this.data.orbiting && (this.zoomPercent > displayTextZoom || (this.isSelected && this.zoomPercent > displayTextZoom ) || (this.isMouseOver && this.zoomPercent > displayTextZoom))
   }
 
   deselectAllText () {

--- a/client/src/game/star.js
+++ b/client/src/game/star.js
@@ -13,10 +13,10 @@ class Star extends EventEmitter {
     Potentially even make user defined.
   */
   static zoomLevelDefinitions = {
-    1: 150,
-    2: 200,
-    3: 250,
-    4: 320
+    1: 0,
+    2: 150,
+    3: 225,
+    4: 300
   }
 
   constructor (app) {
@@ -418,53 +418,64 @@ class Star extends EventEmitter {
   }
 
   drawGarrison () {
-    if (this.text_garrison) {
-      this.text_garrison.texture.destroy(true)
-      this.container.removeChild(this.text_garrison)
-      this.text_garrison = null
+    if (this.text_garrison_small) {
+      this.text_garrison_small.texture.destroy(true)
+      this.container.removeChild(this.text_garrison_small)
+      this.text_garrison_small = null
     }
 
-    if (!this.text_garrison) {
-      let style = Object.assign({}, TextureService.DEFAULT_FONT_STYLE)
-      let small = this.zoomDepth > 2 || this.isSelected
-      style.fontSize = small ? 4 : 7
+    if (this.text_garrison_big) {
+      this.text_garrison_big.texture.destroy(true)
+      this.container.removeChild(this.text_garrison_big)
+      this.text_garrison_big = null
+    }
 
-      let totalKnownGarrison = (this.data.garrison || 0) + this._getStarCarrierGarrison()
+    let style_small = Object.assign({}, TextureService.DEFAULT_FONT_STYLE)
+    let style_big = Object.assign({}, TextureService.DEFAULT_FONT_STYLE)
+    style_small.fontSize = 4
+    style_big.fontSize = 7
 
-      let carriersOrbiting = this._getStarCarriers()
-      let carrierCount = carriersOrbiting.length
+    let totalKnownGarrison = (this.data.garrison || 0) + this._getStarCarrierGarrison()
 
-      let garrisonText = ''
-      let scramblers = 0
-      if (carriersOrbiting) {
-        scramblers = carriersOrbiting.reduce( (sum, c ) => sum + (c.ships==null), 0 )
+    let carriersOrbiting = this._getStarCarriers()
+    let carrierCount = carriersOrbiting.length
+
+    let garrisonText = ''
+    let scramblers = 0
+    if (carriersOrbiting) {
+      scramblers = carriersOrbiting.reduce( (sum, c ) => sum + (c.ships==null), 0 )
+    }
+    if ( (scramblers == carrierCount) && (this.data.garrison == null) ) {
+      garrisonText = '???'
+    }
+    else {
+      garrisonText = totalKnownGarrison
+      if( (scramblers > 0) || (this.data.garrison == null) ) {
+        garrisonText += '*'
       }
-      if ( (scramblers == carrierCount) && (this.data.garrison == null) ) {
-        garrisonText = '???'
-      }
-      else {
-        garrisonText = totalKnownGarrison
-        if( (scramblers > 0) || (this.data.garrison == null) ) {
-          garrisonText += '*'
-        }
-      }
+    }
 
-      if (carrierCount) {
-        garrisonText += '/'
-        garrisonText += carrierCount.toString()
-      }
+    if (carrierCount) {
+      garrisonText += '/'
+      garrisonText += carrierCount.toString()
+    }
 
-      if (garrisonText) {
-        this.text_garrison = new PIXI.Text(garrisonText, style)
-        this.text_garrison.scale.x = 1.5
-        this.text_garrison.scale.y = 1.5
-        this.text_garrison.resolution = 10
+    function make_garrison_text(small) {
+      let text_garrison = new PIXI.Text(garrisonText, small ? style_small : style_big)
+      text_garrison.scale.x = 1.5
+      text_garrison.scale.y = 1.5
+      text_garrison.resolution = 10
 
-        this.text_garrison.x = 5
-        this.text_garrison.y = -this.text_garrison.height + (small ? 1.5 : 6)
+      text_garrison.x = 5
+      text_garrison.y = -text_garrison.height + (small ? 1.5 : 6)
+      return text_garrison
+    }
 
-        this.container.addChild(this.text_garrison)
-      }
+    if (garrisonText) {
+      this.text_garrison_small = make_garrison_text(true)
+      this.text_garrison_big = make_garrison_text(false)
+      this.container.addChild(this.text_garrison_small)
+      this.container.addChild(this.text_garrison_big)
     }
   }
 
@@ -573,7 +584,8 @@ class Star extends EventEmitter {
      if (this.text_name) this.text_name.visible = false
      if (this.container_planets) this.container_planets.visible = false
      if (this.text_infrastructure) this.text_infrastructure.visible = false
-     if (this.text_garrison) this.text_garrison.visible = false
+     if (this.text_garrison_small) this.text_garrison_small.visible = false
+     if (this.text_garrison_big) this.text_garrison_big.visible = false
    } 
    else {
      this.updateVisibility()
@@ -618,9 +630,6 @@ class Star extends EventEmitter {
         // this.setScale()
       }
     }
-
-    //Redraw
-    this.draw()
   }
 
   updateVisibility() {
@@ -630,11 +639,19 @@ class Star extends EventEmitter {
     this.graphics_natural_resources_ring.visible = this._isInScanningRange() && this.zoomDepth >= 4
 
     if (this.text_name) this.text_name.visible = this.isSelected || this.zoomDepth >= 3
-    if (this.container_planets) this.container_planets.visible = this._isInScanningRange() && this.zoomDepth >= 2
+    if (this.container_planets) this.container_planets.visible = this._isInScanningRange() && this.zoomDepth >= 4
     if (this.text_infrastructure) this.text_infrastructure.visible = this.isSelected || this.zoomDepth >= 4
-    if (this.text_garrison) this.text_garrison.visible = !!(this.data.infrastructure && (this.isSelected || this.isMouseOver || this.zoomDepth >= 2))
 
-    let partial_ring = this.text_garrison && this.text_garrison.visible || this.text_name && this.text_name.visible
+    let small_garrison = this.zoomDepth > 2 || this.isSelected
+    let visible_garrison = !!(this.data.infrastructure && (this.isSelected || this.isMouseOver || this.zoomDepth >= 2))
+
+    if (this.text_garrison_small) this.text_garrison_small.visible = small_garrison && visible_garrison
+    if (this.text_garrison_big) this.text_garrison_big.visible = !small_garrison && visible_garrison
+
+    let partial_ring = this.text_garrison_big && this.text_garrison_big.visible
+      || this.text_garrison_small && this.text_garrison_small.visible
+      || this.text_name && this.text_name.visible
+
     this.graphics_shape_part.visible = partial_ring
     this.graphics_shape_full.visible = !partial_ring
     this.graphics_shape_part_warp.visible = partial_ring && this.warpGate
@@ -678,7 +695,7 @@ class Star extends EventEmitter {
     }
 
     //Update everything
-    if (this.zoomDepth != old) this.draw()
+    if (this.zoomDepth != old) this.updateVisibility()
   }
 }
 


### PR DESCRIPTION
This should work but I encourage you to test it.
This almost completely reworks the zooming on stars.

There are a few things I want to note here.
First of all, the way the UpdateVisibility function is spammed causes performance issues, it's okay now but in case that function ever becomes more cpu intensive it could be a bigger issue.
Secondly I support how the game only redraws its textures when needed, but this also comes with issues. Right now text has te be redrawn to support different zoomlevels, and mouseovers/selections. Currently I made it so that the whole star gets redrawn when it changes zoom level or when it gets selected, deselected, in practice only the garrison needs to be redrawn, but this way the chance to create a bug in future additions is smaller.

If you want to prevent redrawing an unchanged texture I can make a system for that. Something where each texture comes with a state, and a function which generates this state. The state defines stuff like fontsize, x/y etc. Of each texture a state of when it was last drawn is preserved. This way the draw function can generate these states, and if they match the preserved state there's no need to redraw.

I also think that maybe classes like stars and carriers should have a parent class so behavior like the new zoom system could be shared among all. Although that might also make implementing new changes to a specific class harder.

