### PR TITLE
Improvement/zoom consistency

### DIFF
--- a/client/src/game/background.js
+++ b/client/src/game/background.js
@@ -210,7 +210,8 @@ class Background {
     }
   }
 
-  onTick (deltaTime, viewportData) {
+  onTick (zoomPercent, deltaTime, viewportData) {
+    this.refreshZoom(zoomPercent)
     this.time += deltaTime*1000
     let compressedTime = this.time*this.timeScale
     for (let i = 0; i < this.container.children.length; i++) {

--- a/client/src/game/container.js
+++ b/client/src/game/container.js
@@ -230,7 +230,7 @@ class GameContainer {
     let viewportWidth = this.viewport.right - this.viewport.left
     let viewportPercent = (this.viewport.screenWidth / viewportWidth) * 100
 
-    return viewportPercent
+    return viewportPercent * window.devicePixelRatio
   }
 
   onTick (deltaTime) {

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -605,6 +605,7 @@ class Map extends EventEmitter {
 
     let zoomPercent = (this.gameContainer.viewport.screenWidth/viewportWidth) * 100
     zoomPercent *= window.devicePixelRatio
+    this.zoomPercent = zoomPercent
 
     let viewportData = {
       center: viewportCenter,
@@ -653,7 +654,7 @@ class Map extends EventEmitter {
     }
 
     this.pathManager.onTick(this.zoomPercent, this.gameContainer.viewport, zoomChanging)
-    this.background.onTick(deltaTime, viewportData)
+    this.background.onTick(this.zoomPercent, deltaTime, viewportData)
     this.playerNames.onTick(this.zoomPercent, zoomChanging)
 
     this.lastZoomPercent = this.zoomPercent

--- a/client/src/game/map.js
+++ b/client/src/game/map.js
@@ -406,6 +406,7 @@ class Map extends EventEmitter {
     this.gameContainer.viewport.moveCenter(empireCenter.x, empireCenter.y)
 
     let zoomPercent = this.gameContainer.getViewportZoomPercentage()
+    zoomPercent *= window.devicePixelRatio
 
     this.refreshZoom(zoomPercent)
   }
@@ -501,6 +502,7 @@ class Map extends EventEmitter {
     let viewportCenter = this.gameContainer.viewport.center
 
     let zoomPercent = (this.gameContainer.viewport.screenWidth/viewportWidth) * 100
+    zoomPercent *= window.devicePixelRatio
 
     let viewportData = {
       center: viewportCenter,


### PR DESCRIPTION
Improves zoom consistency across devices of different DPI, that is, stars text info will appear much sooner on mobile now but will be the same as they where on desktop. Tweaking of default zoom values would probably be necessary since, imo, defaults for text where always too soon on desktop( and now they will be on mobile aswell ). I would get TLH's opinion on this one, aswell as other players that switch between devices often