### PR TITLE
Also ignore Mac's "Command" (Meta) key modifier

### DIFF
--- a/client/src/components/game/menu/HeaderBar.vue
+++ b/client/src/components/game/menu/HeaderBar.vue
@@ -254,7 +254,7 @@ export default {
       let keyCode = e.keyCode || e.which
 
       // Check for modifier keys and ignore the keypress if there is one.
-      if (e.altKey || e.shiftKey || e.ctrlKey) {
+      if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
         return
       }
 


### PR DESCRIPTION
Issue mention on Discord:

https://discord.com/channels/686524791943069734/740693037243564142/844669705288417312

https://discord.com/channels/686524791943069734/740693037243564142/844673922805006367

StackOverflow:

https://stackoverflow.com/questions/3902635/how-does-one-capture-a-macs-command-key-via-javascript

MDN:

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey