### PR TITLE
Skip drawing territories if map has no stars (e.g. dark start)

### DIFF
--- a/client/src/game/territories.js
+++ b/client/src/game/territories.js
@@ -21,6 +21,10 @@ class Territories {
   draw (userSettings) {
     this.container.removeChildren()
 
+    if (!this.game.galaxy.stars || !this.game.galaxy.stars.length) {
+      return; //No territories if we have no stars
+    }
+
     switch(userSettings.map.territoryStyle) {
       case 'marching-square':
         this._drawTerritoriesMarchingCube(userSettings)


### PR DESCRIPTION
Fixes errors in console when entering games in dark start mode