### PR TITLE
Use e.key instead of keyCode for hotkeys

### DIFF
--- a/client/src/components/data/keyboardShortcuts.js
+++ b/client/src/components/data/keyboardShortcuts.js
@@ -2,28 +2,28 @@ import MENU_STATES from './menuStates'
 
 export default {
   all: {
-    '27': null, // Esc
-    '81': MENU_STATES.LEADERBOARD, // Q
-    '187': 'ZOOM_IN', // +
-    '189': 'ZOOM_OUT', // -
-    '90': 'FIT_GALAXY' // Z
+    'Escape': null,
+    'q': MENU_STATES.LEADERBOARD,
+    '+': 'ZOOM_IN',
+    '-': 'ZOOM_OUT',
+    'z': 'FIT_GALAXY'
   },
   user: {
-    '67': MENU_STATES.COMBAT_CALCULATOR, // C
-    '86': MENU_STATES.RULER, // V
-    '73': MENU_STATES.INTEL, // I
-    '79': MENU_STATES.OPTIONS, // O
+    'c': MENU_STATES.COMBAT_CALCULATOR,
+    'v': MENU_STATES.RULER,
+    'i': MENU_STATES.INTEL,
+    'o': MENU_STATES.OPTIONS,
   },
   player: {
-    '72': 'HOME_STAR', // H
-    '32': 'HOME_STAR', // Space
-    '82': MENU_STATES.RESEARCH, // R
-    '71': `${MENU_STATES.GALAXY}|stars`, // G
-    '70': `${MENU_STATES.GALAXY}|carriers`, // F
-    '83': `${MENU_STATES.GALAXY}|ships`, // S
-    '77': MENU_STATES.INBOX, // M
-    '78': MENU_STATES.GAME_NOTES, // N
-    '76': MENU_STATES.LEDGER, // L
-    '66': MENU_STATES.BULK_INFRASTRUCTURE_UPGRADE, // B
+    'h': 'HOME_STAR',
+    ' ': 'HOME_STAR', // Space
+    'r': MENU_STATES.RESEARCH,
+    'g': `${MENU_STATES.GALAXY}|stars`,
+    'f': `${MENU_STATES.GALAXY}|carriers`,
+    's': `${MENU_STATES.GALAXY}|ships`,
+    'm': MENU_STATES.INBOX,
+    'n': MENU_STATES.GAME_NOTES,
+    'l': MENU_STATES.LEDGER,
+    'b': MENU_STATES.BULK_INFRASTRUCTURE_UPGRADE,
   }
 }

--- a/client/src/components/game/menu/HeaderBar.vue
+++ b/client/src/components/game/menu/HeaderBar.vue
@@ -274,7 +274,7 @@ export default {
     handleKeyDown (e) {
       if (/^(?:input|textarea|select|button)$/i.test(e.target.tagName)) return
 
-      let keyCode = e.keyCode || e.which
+      let key = e.key
 
       // Check for modifier keys and ignore the keypress if there is one.
       if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
@@ -284,16 +284,16 @@ export default {
       let isLoggedIn = this.$store.state.userId != null
       let isInGame = this.userPlayer != null
 
-      let menuState = KEYBOARD_SHORTCUTS.all[keyCode.toString()]
+      let menuState = KEYBOARD_SHORTCUTS.all[key]
 
       if (isLoggedIn) {
-        menuState = menuState || KEYBOARD_SHORTCUTS.user[keyCode.toString()]
+        menuState = menuState || KEYBOARD_SHORTCUTS.user[key]
       }
 
       // Handle keyboard shortcuts for screens only available for users
       // who are players.
       if (isInGame) {
-        menuState = menuState || KEYBOARD_SHORTCUTS.player[keyCode.toString()]
+        menuState = menuState || KEYBOARD_SHORTCUTS.player[key]
       }
 
       if (!menuState) {


### PR DESCRIPTION
e.keyCode is deprecated as it is browser/system dependent and using e.key is consistent across browsers and systems.
Note that using e.key the hotkeys can change physical key position from keyboard to keyboard. E.g. pressing Q on a QWERTY keyboard will be a different key to pressing Q on an AZERTY keyboard.
This is likely the behaviour that we want for this game as the description of the keys seem to be hardcoded in the hamburger menus and such (e.g. "Ruler (V)" and "Calculator (C)").

This PR closes issue #475.