### PR TITLE
fixed distanceToDestination being too high when carrier arrives

### DIFF
--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -483,15 +483,21 @@ module.exports = class CarrierService {
         }
 
         let nextLocation;
-        let distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
+        let distancePerTick;
         let distanceToDestination = this.distanceService.getDistanceBetweenLocations(carrier.location, destinationStar.location);
 
 
-        if (instantSpeed || (distancePerTick >= distanceToDestination) ) {
+        if (instantSpeed) {
             distancePerTick = distanceToDestination;
             nextLocation = destinationStar.location;
         } else {
-            nextLocation = this.distanceService.getNextLocationTowardsLocation(carrier.location, destinationStar.location, distancePerTick);
+            distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
+            if (distancePerTick >= distanceToDestination) {
+                distancePerTick = distanceToDestination;
+                nextLocation = destinationStar.location;
+            } else{
+                nextLocation = this.distanceService.getNextLocationTowardsLocation(carrier.location, destinationStar.location, distancePerTick);
+            }
         }
 
         return {

--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -483,13 +483,14 @@ module.exports = class CarrierService {
         }
 
         let nextLocation;
-        let distancePerTick;
+        let distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
+        let distanceToDestination = this.distanceService.getDistanceBetweenLocations(carrier.location, destinationStar.location);
 
-        if (instantSpeed) {
-            distancePerTick = this.distanceService.getDistanceBetweenLocations(carrier.location, destinationStar.location);
+
+        if (instantSpeed || (distancePerTick >= distanceToDestination) ) {
+            distancePerTick = distanceToDestination;
             nextLocation = destinationStar.location;
         } else {
-            distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
             nextLocation = this.distanceService.getNextLocationTowardsLocation(carrier.location, destinationStar.location, distancePerTick);
         }
 

--- a/server/services/distance.js
+++ b/server/services/distance.js
@@ -52,6 +52,8 @@ module.exports = class DistanceService {
     }
 
     getNextLocationTowardsLocation(source, destination, distance) {
+        // SUPER IMPORTANT: This moves the object just in the direction of the destination by the input distance, meaning it can totally overshoot when using this formula!!!
+        // Uses of this formula however catch this case and fix it, but be aware when picking it for a new function. 
         let angle = this.getAngleTowardsLocation(source, destination);
 
         return {


### PR DESCRIPTION
Currently when a carrier arrives at a star, the c2c combat calculation sees the:

Math.abs(distanceToDestination - distancePerTick) as the new distance to the star, even when it arrives. Meaning it can trigger c2c combat when it doesnt apply. This new code sets the newDistanceToDestination to 0 when the carrier is arriving at the star in combatcalculation (it only breaks in combatcalculation)

Note that when carriers arrive at a star in the same tick from the same source they always engage in c2c combat before arrival. This is a problem to fix in the future
