### PR TITLE
Performance/marching square generation

### DIFF
--- a/client/src/game/territories.js
+++ b/client/src/game/territories.js
@@ -139,24 +139,27 @@ class Territories {
     let startIX, endIX, startIY, endIY, gridLocation, distance, owner;
     let stars = this.game.galaxy.stars
     for (let star of stars) {
-      startIX = Math.ceil((star.location.x - METABALL_RADIUS - minX) / CELL_SIZE);
-      endIX = Math.floor((star.location.x + METABALL_RADIUS - minX) / CELL_SIZE);
+      // This loop goes through all stars, and generates the gridPoints that are within the METABALL_RADIUS
+      // Those points get the value of this star, or keep their previous value (from another star) if that one was closer
+      startIX = Math.ceil((star.location.x - METABALL_RADIUS - minX) / CELL_SIZE); //The minimum ix can be and still be in the METABALL_RADIUS
+      endIX = Math.floor((star.location.x + METABALL_RADIUS - minX) / CELL_SIZE); //The maximum ix can be and still be in the METABALL_RADIUS
       for (let ix = startIX; ix <= endIX; ix++) {
-        startIY = Math.ceil((star.location.y - Math.sqrt((METABALL_RADIUS)**2 - (star.location.x - (ix * CELL_SIZE + minX))**2) - minY) / CELL_SIZE);
-        endIY = Math.floor((star.location.y + Math.sqrt((METABALL_RADIUS)**2 - (star.location.x - (ix * CELL_SIZE + minX))**2) - minY) / CELL_SIZE);
+        startIY = Math.ceil((star.location.y - Math.sqrt((METABALL_RADIUS)**2 - (star.location.x - (ix * CELL_SIZE + minX))**2) - minY) / CELL_SIZE); // The minimum iy can be and still be in the METABALL_RADIUS
+        endIY = Math.floor((star.location.y + Math.sqrt((METABALL_RADIUS)**2 - (star.location.x - (ix * CELL_SIZE + minX))**2) - minY) / CELL_SIZE); // The maximum iy can be and still be in the METABALL_RADIUS
         for (let iy = startIY; iy <= endIY; iy++) {
-          gridLocation = gridToCoord(ix, iy);
-          distance = gameHelper.getDistanceBetweenLocations(gridLocation, star.location);
-          if (samplePoints[ix][iy] && samplePoints[ix][iy].distance < distance) {
+          gridLocation = gridToCoord(ix, iy); // Get the location in x, y of the gridPoint we are currently looping through
+          distance = gameHelper.getDistanceBetweenLocations(gridLocation, star.location); // Get the distance between the gridPoint and the star
+          if (samplePoints[ix][iy] && samplePoints[ix][iy].distance < distance) { // If the gridpoint has a value AND the distance currently logged (from a previous star) is smaller than the current one THEN don't log anything
             // Do nothing, because the grid already has a value from a star that is closer
           } else {
             // Now either the grid doesn't have a value here yet or the star calculated here is closer than the one currently logged in
             owner = this.game.galaxy.players.find(p => p._id === star.ownedByPlayerId)
-            samplePoints[ix][iy] = { distance, owner };
+            samplePoints[ix][iy] = { distance, owner }; // Make this gridPoint the value of the distance from the star so we can compare it with other stars AND make it have the value for the owner (the player)
           }
         }
       }
     }
+    // Loops through all samplePoints, to make the value of the point the owner, instead of {distance, owner} because that is what the next function takes as input.
     for (let ix = 0; ix < samplePoints.length - 1; ix++) {
       for (let iy = 0; iy < samplePoints[ix].length - 1; iy++) {
         if (samplePoints[ix][iy]) {

--- a/client/src/game/territories.js
+++ b/client/src/game/territories.js
@@ -127,32 +127,44 @@ class Territories {
     let gridWidth = (maxX - minX) / CELL_SIZE
     let gridHeight = (maxY - minY) / CELL_SIZE
 
-    let samplePoints = new Array(gridWidth + 1)
+    let samplePoints = Array.from(Array(gridWidth + 1), () => new Array(gridHeight + 1));
 
-    for (let ix = 0; ix < samplePoints.length; ix++) {
-      samplePoints[ix] = new Array(gridHeight + 1)
-      for (let iy = 0; iy < samplePoints[ix].length; iy++) {
-        // find the closest star and its owner
-        let pointLocation = { x: ix * CELL_SIZE + minX, y: iy * CELL_SIZE + minY }
-        let closestStar = gameHelper.getClosestStar(this.game.galaxy.stars, pointLocation)
-        let owner = this.game.galaxy.players.find(p => p._id === closestStar.star.ownedByPlayerId)
-        // TODO get the intensity of the metaball composed of all stars of the owner
-        // the owner stars shouold be cached outside this loop
-
-        if (closestStar.distance < METABALL_RADIUS) {
-          samplePoints[ix][iy] = owner
-        }
-        if (false) {
-          let pointGraphics = new PIXI.Graphics()
-          pointGraphics.lineStyle(1, samplePoints[ix][iy], 1.0)
-          pointGraphics.drawStar(0, 0, 5, 5, 5 - 2)
-          pointGraphics.position.x = pointLocation.x
-          pointGraphics.position.y = pointLocation.y
-          this.container.addChild(pointGraphics)
-        }
-
+    const gridToCoord = (ix, iy) => {
+      return {
+        x: ix * CELL_SIZE + minX,
+        y: iy * CELL_SIZE + minY
       }
     }
+
+    let startIX, endIX, startIY, endIY, gridLocation, distance, owner;
+    let stars = this.game.galaxy.stars
+    for (let star of stars) {
+      startIX = Math.ceil((star.location.x - METABALL_RADIUS - minX) / CELL_SIZE);
+      endIX = Math.floor((star.location.x + METABALL_RADIUS - minX) / CELL_SIZE);
+      for (let ix = startIX; ix <= endIX; ix++) {
+        startIY = Math.ceil((star.location.y - Math.sqrt((METABALL_RADIUS)**2 - (star.location.x - (ix * CELL_SIZE + minX))**2) - minY) / CELL_SIZE);
+        endIY = Math.floor((star.location.y + Math.sqrt((METABALL_RADIUS)**2 - (star.location.x - (ix * CELL_SIZE + minX))**2) - minY) / CELL_SIZE);
+        for (let iy = startIY; iy <= endIY; iy++) {
+          gridLocation = gridToCoord(ix, iy);
+          distance = gameHelper.getDistanceBetweenLocations(gridLocation, star.location);
+          if (samplePoints[ix][iy] && samplePoints[ix][iy].distance < distance) {
+            // Do nothing, because the grid already has a value from a star that is closer
+          } else {
+            // Now either the grid doesn't have a value here yet or the star calculated here is closer than the one currently logged in
+            owner = this.game.galaxy.players.find(p => p._id === star.ownedByPlayerId)
+            samplePoints[ix][iy] = { distance, owner };
+          }
+        }
+      }
+    }
+    for (let ix = 0; ix < samplePoints.length - 1; ix++) {
+      for (let iy = 0; iy < samplePoints[ix].length - 1; iy++) {
+        if (samplePoints[ix][iy]) {
+          samplePoints[ix][iy] = samplePoints[ix][iy].owner;
+        }
+      }
+    }
+
     for (let player of this.game.galaxy.players) {
       let color = player.colour.value
       let territoryPolygons = new PIXI.Graphics()
@@ -281,7 +293,7 @@ class Territories {
         endpointCheck(cell, halfedge.getEndpoint())
       }
     }
-    
+
     // Draw the cells
     for (let cell of diagram.cells) {
       let star = this.game.galaxy.stars.find(s => s.location.x === cell.site.x && s.location.y === cell.site.y);

--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -510,25 +510,15 @@ module.exports = class CarrierService {
         }
 
         let nextLocation;
-        let distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
-        let distanceToDestination = this.distanceService.getDistanceBetweenLocations(carrier.location, destinationStar.location);
+        let distancePerTick;
 
-
-        if (instantSpeed || (distancePerTick >= distanceToDestination) ) {
-            distancePerTick = distanceToDestination;
+        if (instantSpeed) {
+            distancePerTick = this.distanceService.getDistanceBetweenLocations(carrier.location, destinationStar.location);
             nextLocation = destinationStar.location;
         } else {
+            distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
             nextLocation = this.distanceService.getNextLocationTowardsLocation(carrier.location, destinationStar.location, distancePerTick);
         }
-
-        return {
-            location: nextLocation,
-            distance: distancePerTick,
-            warpSpeed,
-            instantSpeed,
-            sourceStar,
-            destinationStar
-        };
     }
 
     isInTransit(carrier) {

--- a/server/services/carrier.js
+++ b/server/services/carrier.js
@@ -519,6 +519,15 @@ module.exports = class CarrierService {
             distancePerTick = this.getCarrierDistancePerTick(game, carrier, warpSpeed, instantSpeed);
             nextLocation = this.distanceService.getNextLocationTowardsLocation(carrier.location, destinationStar.location, distancePerTick);
         }
+
+        return {
+            location: nextLocation,
+            distance: distancePerTick,
+            warpSpeed,
+            instantSpeed,
+            sourceStar,
+            destinationStar
+        };
     }
 
     isInTransit(carrier) {

--- a/server/services/distance.js
+++ b/server/services/distance.js
@@ -52,8 +52,6 @@ module.exports = class DistanceService {
     }
 
     getNextLocationTowardsLocation(source, destination, distance) {
-        // SUPER IMPORTANT: This moves the object just in the direction of the destination by the input distance, meaning it can totally overshoot when using this formula!!!
-        // Uses of this formula however catch this case and fix it, but be aware when picking it for a new function. 
         let angle = this.getAngleTowardsLocation(source, destination);
 
         return {


### PR DESCRIPTION
Made this to speed up the drawing of the marching square. I can't do accurate performance tests, so those are requested, but my function did seem about 75% faster than the previous one installed for a 32p 50spp, though it is dependent on the METABALL_RADIUS a user chooses on how efficient it is. Worst case scenario (maximum METABALL_RADIUS) should be as efficient as the current system, for all normal users the improvement is (again) 75% 