### PR TITLE
Fix missing countdown timers when opening active games list for the first time

### DIFF
--- a/client/src/components/CountdownTimer.vue
+++ b/client/src/components/CountdownTimer.vue
@@ -18,10 +18,8 @@ export default {
         }
     },
     mounted () {
-        if (!GameHelper.isGameFinished(this.$store.state.game)) {
-            this.recalculateTime();
-            this.intervalFunction = setInterval(this.recalculateTime, 1000);
-        }
+        this.recalculateTime();
+        this.intervalFunction = setInterval(this.recalculateTime, 1000);
     },
     destroyed () {
         if (this.intervalFunction) {


### PR DESCRIPTION
Fixes the following bug:
> For the last couple of days, when I first login to Solaris and check my games page, it is missing the "time till next cycle" timer - but only on my phone - if I go into game and then come out again, the timer is back.