### PR TITLE
Fixes a broken url in $help and leaderboards not generating

### DIFF
--- a/server/bots/discord/services/publicCommand.ts
+++ b/server/bots/discord/services/publicCommand.ts
@@ -109,7 +109,7 @@ export default class PublicCommandService {
     async help(msg, directions: string[]) {
         //$help
         let id = msg.author.id;
-        let response = `Hey <@${id}>,\nPlease visit https://github.com/mike-eason/solaris/blob/master/bots/discord/README.md for help on how to interact with me.`;
+        let response = `Hey <@${id}>,\nPlease visit https://github.com/mike-eason/solaris/blob/master/server/bots/discord/README.md for help on how to interact with me.`;
         return msg.channel.send(response);
     }
 

--- a/server/services/leaderboard.ts
+++ b/server/services/leaderboard.ts
@@ -581,7 +581,7 @@ export default class LeaderboardService {
 
         let playerStats = game.galaxy.players.map(p => {
             let isKingOfTheHill = kingOfTheHillPlayer != null && p._id.toString() === kingOfTheHillPlayer._id.toString();
-            let stats = this.playerStatisticsService.getStats(game, p);
+            let stats = p.stats ?? this.playerStatisticsService.getStats(game, p);
 
             return {
                 player: p,

--- a/server/services/leaderboard.ts
+++ b/server/services/leaderboard.ts
@@ -586,7 +586,6 @@ export default class LeaderboardService {
             return {
                 player: p,
                 isKingOfTheHill,
-                // stats: p.stats ? p.stats : this.playerStatisticsService.getStats(game, p) //This makes sure that when the function is called with a hidden galaxy (what a player sees) it will use the already generated stats.
                 stats
             };
         });


### PR DESCRIPTION
Basically changed the url in $help.

And added the p.stats ?? .... in the leaderboard generating commands. Meaning games that already have player stats generated can also be an input.